### PR TITLE
fix: correct a typo regarding parabola root

### DIFF
--- a/parabole.tex
+++ b/parabole.tex
@@ -182,7 +182,7 @@ Le résultat est à la figure \ref{LabelFigParaboleiLbviP}.
     \begin{equation}
         f(x)=(x-3)(x-8).
     \end{equation}
-    Le fait que cela s'annule en \( x=3\) et \( x=5\) est immédiat. En développant nous pouvons également l'écrire
+    Le fait que cela s'annule en \( x=3\) et \( x=8\) est immédiat. En développant nous pouvons également l'écrire
     \begin{equation}
         f(x)=(x-3)(x-8)=x^2-8x-3x+24=x^2-11x+24.
     \end{equation}


### PR DESCRIPTION
I have found a little typo in `parabole.tex`: 

```
     \begin{equation}
        f(x)=(x-3)(x-8).
    \end{equation}
    Le fait que cela s'annule en \( x=3\) et \( x=5\) est immédiat. En développant nous pouvons également l'écrire
```

`(x-3)(x-8)` roots are `x=3` and `x=8` 😸 .